### PR TITLE
Do not crash if alpha detection fails

### DIFF
--- a/lib/active_analysis/analyzer/image_analyzer/vips.rb
+++ b/lib/active_analysis/analyzer/image_analyzer/vips.rb
@@ -42,6 +42,8 @@ module ActiveAnalysis
       def opaque?(image)
         return true unless image.has_alpha?
         image[image.bands - 1].min == 255
+      rescue ::Vips::Error
+        false
       end
 
       def valid_image?(image)


### PR DESCRIPTION
Rescue if has_alpha? fails due to < 8.5 version in Ubuntu 18.04 CIs